### PR TITLE
Update to image 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ log = "0.4"
 flate2 = "1.0"
 bitflags = "1.2"
 nohash = "0.2"
-image = { version = "0.23", default-features = false }
+image = { version = "0.24", default-features = false }
 
 [dev-dependencies]
 rand = ">=0.7, <0.9"
 rect_packer = "0.2"
-image = { version = "0.23", default-features = false, features = ["png"] }
+image = { version = "0.24", default-features = false, features = ["png"] }

--- a/examples/atlas/main.rs
+++ b/examples/atlas/main.rs
@@ -72,8 +72,8 @@ fn main() {
         image::imageops::replace(
             &mut output,
             &img.image,
-            img.location.x as u32,
-            img.location.y as u32,
+            img.location.x.into(),
+            img.location.y.into(),
         );
     }
     let output_file = basedir.join("atlas.png");

--- a/src/pixel.rs
+++ b/src/pixel.rs
@@ -1,4 +1,4 @@
-use image::{Pixel, Rgba};
+use image::Rgba;
 
 use crate::{reader::AseReader, AsepriteParseError, ColorPalette, PixelFormat, Result};
 use std::{borrow::Cow, io::Read, sync::Arc};
@@ -14,8 +14,8 @@ fn read_rgba(chunk: &[u8]) -> Result<Rgba<u8>> {
     let red = reader.byte()?;
     let green = reader.byte()?;
     let blue = reader.byte()?;
-    let alpha = reader.byte()?;
-    Ok(Rgba::from_channels(red, green, blue, alpha))
+    let alpha: u8 = reader.byte()?;
+    Ok(Rgba([red, green, blue, alpha]))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -34,7 +34,7 @@ impl Grayscale {
 
     pub(crate) fn into_rgba(self) -> Rgba<u8> {
         let Self { value, alpha } = self;
-        Rgba::from_channels(value, value, value, alpha)
+        Rgba([value, value, value, alpha])
     }
 }
 
@@ -59,7 +59,7 @@ impl Indexed {
             } else {
                 c.alpha()
             };
-            Rgba::from_channels(c.red(), c.green(), c.blue(), alpha)
+            Rgba([c.red(), c.green(), c.blue(), alpha])
         })
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,3 @@
-use image::Pixel;
-
 use crate::*;
 use std::path::PathBuf;
 
@@ -71,7 +69,7 @@ fn is_transparent(col: &image::Rgba<u8>) -> bool {
 fn test_user_data(s: &str, c: [u8; 4]) -> UserData {
     UserData {
         text: Some(s.to_string()),
-        color: Some(image::Rgba::from_channels(c[0], c[1], c[2], c[3])),
+        color: Some(image::Rgba(c)),
     }
 }
 
@@ -535,7 +533,7 @@ fn user_data_tags() {
 
     let expected_second = UserData {
         text: None,
-        color: Some(image::Rgba::from_channels(0, 0, 0, 255)),
+        color: Some(image::Rgba([0, 0, 0, 255])),
     };
     assert_eq!(*second, expected_second);
 

--- a/src/user_data.rs
+++ b/src/user_data.rs
@@ -1,5 +1,4 @@
 use crate::{reader::AseReader, Result};
-use image::Pixel;
 
 /// User-provided metadata which can be attached to various items.
 ///
@@ -29,7 +28,7 @@ pub(crate) fn parse_userdata_chunk(data: &[u8]) -> Result<UserData> {
         let green = reader.byte()?;
         let blue = reader.byte()?;
         let alpha = reader.byte()?;
-        let rgba = image::Rgba::from_channels(red, green, blue, alpha);
+        let rgba = image::Rgba([red, green, blue, alpha]);
         Some(rgba)
     } else {
         None


### PR DESCRIPTION
Updates image to 0.24.

Useful because image is exposed by this crate so if you don't use the latest version here, none of your dependencies can either.

I had to make some very minor updates to fix deprecation warnings and compilation issues (namely the .into() instead of as u32 and using the new Rgba constructor).