### PR TITLE
Bump image dependency to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,4 @@ image = { version = "0.24", default-features = false }
 [dev-dependencies]
 rand = ">=0.7, <0.9"
 rect_packer = "0.2"
-image = { version = "0.23", default-features = false, features = ["png"] }
+image = { version = "0.24", default-features = false, features = ["png"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ log = "0.4"
 flate2 = "1.0"
 bitflags = "1.2"
 nohash = "0.2"
-image = { version = "0.23", default-features = false }
+image = { version = "0.24", default-features = false }
 
 [dev-dependencies]
 rand = ">=0.7, <0.9"

--- a/examples/atlas/main.rs
+++ b/examples/atlas/main.rs
@@ -72,8 +72,8 @@ fn main() {
         image::imageops::replace(
             &mut output,
             &img.image,
-            img.location.x as u32,
-            img.location.y as u32,
+            img.location.x as i64,
+            img.location.y as i64,
         );
     }
     let output_file = basedir.join("atlas.png");


### PR DESCRIPTION
Just bumps image crate to 0.24 and fixes the atlas example.